### PR TITLE
Fix Tauri start-up on Mint by forcing safe GTK/WebKit env in dev containers

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,13 +1,54 @@
 mod vault;
 
-#[cfg_attr(mobile, tauri::mobile_entry_point)]
-pub fn run() {
+#[cfg(target_os = "linux")]
+fn configure_linux_env() {
+    use std::{env, path::Path};
+
+    fn set_env_if_unset(key: &str, value: &str) {
+        if env::var_os(key).is_none() {
+            env::set_var(key, value);
+        }
+    }
+
     // Cinnamon and similar Linux desktops often lack an accessibility bus, which causes
     // GTK/Wry to spam errors and sometimes abort the launch. Force-disable the AT-SPI
     // bridge when it is not explicitly configured.
-    if std::env::var_os("NO_AT_BRIDGE").is_none() {
-        std::env::set_var("NO_AT_BRIDGE", "1");
+    set_env_if_unset("NO_AT_BRIDGE", "1");
+
+    let session_type = env::var("XDG_SESSION_TYPE").unwrap_or_default();
+    let display = env::var("DISPLAY").ok();
+    let wayland_display = env::var("WAYLAND_DISPLAY").ok();
+    let inferred_x11 = session_type.eq_ignore_ascii_case("x11")
+        || (session_type.is_empty() && display.is_some() && wayland_display.is_none());
+    let is_container = ["/run/.containerenv", "/.dockerenv"]
+        .into_iter()
+        .any(|p| Path::new(p).exists())
+        || env::var("DEVCONTAINER").is_ok()
+        || env::var("VSCODE_GIT_IPC_HANDLE").is_ok();
+
+    if inferred_x11 && is_container {
+        set_env_if_unset("LIBGL_ALWAYS_SOFTWARE", "1");
+        set_env_if_unset("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+        set_env_if_unset("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        set_env_if_unset("GDK_DISABLE_SHM", "1");
+        set_env_if_unset("WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS", "1");
     }
+
+    println!(
+        "[liminal-notes bootstrap] session_type={session_type:?} inferred_x11={inferred_x11} in_container={is_container} DISPLAY={display:?} WAYLAND_DISPLAY={wayland_display:?} NO_AT_BRIDGE={:?} WEBKIT_DISABLE_COMPOSITING_MODE={:?} WEBKIT_DISABLE_DMABUF_RENDERER={:?} WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS={:?} GDK_DISABLE_SHM={:?} LIBGL_ALWAYS_SOFTWARE={:?}",
+        env::var("NO_AT_BRIDGE").ok(),
+        env::var("WEBKIT_DISABLE_COMPOSITING_MODE").ok(),
+        env::var("WEBKIT_DISABLE_DMABUF_RENDERER").ok(),
+        env::var("WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS").ok(),
+        env::var("GDK_DISABLE_SHM").ok(),
+        env::var("LIBGL_ALWAYS_SOFTWARE").ok(),
+    );
+}
+
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
+    #[cfg(target_os = "linux")]
+    configure_linux_env();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())


### PR DESCRIPTION
- Detect when we’re inside the VS Code dev container on X11 (check `/.dockerenv`, `/run/.containerenv`, `DEVCONTAINER`, etc.) and only then force WebKit/GTK to use software rendering, disable dmabuf/shm, and turn off the sandbox; bare-metal desktops keep their defaults.
- Always set `NO_AT_BRIDGE=1` if unset so GTK/Wry doesn’t spam dbus warnings on Cinnamon/other desktops without an accessibility bus.
- Emit a concise bootstrap log line summarizing the inferred session and env so future debugging is easier.