### PR TITLE
Add missing window capabilities for always-on-top and decorations

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -14,6 +14,8 @@
     "core:window:allow-minimize",
     "core:window:allow-toggle-maximize",
     "core:window:allow-close",
-    "core:window:allow-start-dragging"
+    "core:window:allow-start-dragging",
+    "core:window:allow-set-always-on-top",
+    "core:window:allow-set-decorations"
   ]
 }


### PR DESCRIPTION
This PR adds missing Tauri dependencies to the `default.json` file.