### PR TITLE
Add workflow to publish site to GitHub Pages

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -1,0 +1,55 @@
+name: publish-site
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/site/**"
+      - "assets/branding/**"
+      - "scripts/prepare-site.mjs"
+      - ".github/workflows/publish-site.yml"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Prepare site assets
+        run: node scripts/prepare-site.mjs
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload site bundle
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/site/public
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
- add GitHub Actions workflow to build static site assets and publish `apps/site/public` to GitHub Pages
- trigger on main branch updates to site files, shared branding assets, or site prep script, plus manual dispatch
- configure required Pages permissions, concurrency guard, and asset preparation step