### PR TITLE
Fix desktop publish workflow Tauri CLI invocation

### DIFF
--- a/.github/workflows/publish-desktop.yml
+++ b/.github/workflows/publish-desktop.yml
@@ -170,7 +170,7 @@ jobs:
           projectPath: apps/desktop
           releaseId: ${{ needs.prepare-release.outputs.release_id }}
           includeUpdaterJson: false
-          tauriScript: "cargo tauri"
+          tauriScript: "pnpm tauri"
 
   publish-windows:
     needs: prepare-release
@@ -235,7 +235,7 @@ jobs:
           projectPath: apps/desktop
           releaseId: ${{ needs.prepare-release.outputs.release_id }}
           includeUpdaterJson: false
-          tauriScript: "cargo tauri"
+          tauriScript: "pnpm tauri"
           args: --target ${{ matrix.target }}
 
       - name: Generate Windows checksums


### PR DESCRIPTION
## Summary
- update desktop publish workflow to call Tauri via `pnpm tauri` instead of `cargo tauri`
- apply the change to both Linux and Windows publish jobs

## Root Cause
- failed runs used `cargo tauri ...` but the runners did not have `cargo-tauri` installed
- all matrix jobs failed with: `error: no such command: tauri`

## Why this fix
- `apps/desktop/package.json` already includes `@tauri-apps/cli`
- workflow already runs `pnpm run ci:install`, so `pnpm tauri` is available and consistent across runners

## Validation
- strict YAML parse validation for `.github/workflows/publish-desktop.yml`
