### PR TITLE
Exclude mobile PRs from desktop generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,4 +1,7 @@
 changelog:
+  exclude:
+    labels:
+      - mobile
   categories:
     - title: Features
       labels:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -53,6 +53,8 @@ This document describes the process for creating a new release of the desktop ap
     - Verify that Linux and Windows assets are present.
     - Confirm the generated release notes look correct.
       - Generated note categories are configured in `.github/release.yml`.
+      - PRs labelled `mobile` are excluded from desktop release notes.
+      - Keep PR labels accurate so generated notes remain platform-specific.
     - If needed, edit the release text with additional context.
 
 6.  **Optional Draft Mode**


### PR DESCRIPTION
## Summary
- exclude PRs labelled `mobile` from GitHub auto-generated release notes
- document the label-based exclusion rule in desktop release docs

## Changes
- `.github/release.yml`
  - added `changelog.exclude.labels: [mobile]`
- `docs/RELEASING.md`
  - noted that `mobile`-labelled PRs are excluded from desktop release notes
  - clarified that accurate PR labels are required for clean generated notes

## Why
- this monorepo was including mobile-only PR entries in desktop release notes
- label-based filtering keeps release notes platform-specific with minimal process change
