### PR TITLE
Bump desktop app version to 0.2.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@liminal-notes/desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Liminal Notes",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "ca.liminal-notes.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
- bump desktop app version to `0.2.0`
- keep `package.json` and `tauri.conf.json` versions aligned

## Files Updated
- `apps/desktop/package.json`
- `apps/desktop/src-tauri/tauri.conf.json`

## Notes
- no tag was created in this change
- this PR prepares version metadata for the next desktop release cut
