### PR TITLE
Fix Windows publish summary PowerShell parser error

### DIFF
--- a/.github/workflows/publish-desktop.yml
+++ b/.github/workflows/publish-desktop.yml
@@ -296,12 +296,12 @@ jobs:
           @(
             '## Windows Publish Summary'
             ''
-            "- Architecture: `${{ matrix.arch }}`"
-            "- Target triple: `${{ matrix.target }}`"
-            "- Build and upload: `$env:BUILD_RESULT`"
-            "- Generate checksums: `$env:CHECKSUM_RESULT`"
-            "- Attach checksums: `$env:ATTACH_RESULT`"
-            "- Release tag: `$env:TAG_NAME`"
+            "- Architecture: ${{ matrix.arch }}"
+            "- Target triple: ${{ matrix.target }}"
+            "- Build and upload: $env:BUILD_RESULT"
+            "- Generate checksums: $env:CHECKSUM_RESULT"
+            "- Attach checksums: $env:ATTACH_RESULT"
+            "- Release tag: $env:TAG_NAME"
             "- Release URL: $env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/releases/tag/$env:TAG_NAME"
             "- Run URL: $env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
           ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append


### PR DESCRIPTION
## Summary
- fix PowerShell parser failure in the Windows publish summary step of `publish-desktop.yml`
- keep summary reporting behaviour, while making summary strings PowerShell-safe

## Root Cause
- summary lines used markdown backticks inside double-quoted PowerShell strings, for example:
  - `"- Target triple: \`aarch64-pc-windows-msvc\`"`
- PowerShell treats backticks as escape characters, which broke string parsing and caused:
  - `You must provide a value expression following the '-' operator.`

## Changes
- remove markdown backticks from Windows summary output lines
- leave summary content and links intact

## Result
- `Summarise Windows publish job` no longer fails with exit code 1
- job still reports build/checksum/release status with `if: always()`
