### PR TITLE
🎨 Palette: Improve tab close button UX

### DIFF
--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -422,7 +422,7 @@ button:disabled {
   border: none;
   color: inherit;
   font-size: 1.1rem;
-  padding: 0 4px;
+  padding: 0;
   border-radius: 50%;
   opacity: 0.6;
   display: flex;

--- a/apps/desktop/src/components/Editor/Tab.tsx
+++ b/apps/desktop/src/components/Editor/Tab.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { OpenTab } from '../../types/tabs';
+import { XMarkIcon } from '../Icons';
 
 interface TabProps {
   tab: OpenTab;
@@ -34,8 +35,9 @@ export function Tab({ tab, isActive, onSelect, onClose, onDoubleClick, onContext
           onClose(e);
         }}
         title="Close Tab"
+        aria-label="Close tab"
       >
-        ×
+        <XMarkIcon size={12} />
       </button>
     </div>
   );


### PR DESCRIPTION
This change improves the visual polish of the editor tabs by replacing the generic "×" character with a proper SVG icon (`XMarkIcon`) that matches the rest of the application's iconography. It also adds an `aria-label` to the close button, improving accessibility for screen reader users. The CSS was updated to remove padding that is no longer needed for the SVG icon, ensuring it remains perfectly centered within the circular button.

---
*PR created automatically by Jules for task [12344707818323890379](https://jules.google.com/task/12344707818323890379) started by @ScottMorris*